### PR TITLE
Add reference price MQTT pipeline

### DIFF
--- a/core/services/timescale_client.py
+++ b/core/services/timescale_client.py
@@ -608,3 +608,29 @@ class TimescaleClient:
             grid_params["limit"],
             grid_params["side"]
         )
+
+    async def create_reference_prices_table(self, table_name: str = "reference_prices"):
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {table_name} (
+                    timestamp TIMESTAMPTZ NOT NULL,
+                    broker TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    price NUMERIC NOT NULL,
+                    PRIMARY KEY (timestamp, broker, symbol)
+                )
+                """
+            )
+
+    async def append_reference_prices(self, table_name: str, records: List[Tuple[float, str, str, float]]):
+        async with self.pool.acquire() as conn:
+            await self.create_reference_prices_table(table_name)
+            await conn.executemany(
+                f"""
+                INSERT INTO {table_name} (timestamp, broker, symbol, price)
+                VALUES (to_timestamp($1), $2, $3, $4)
+                ON CONFLICT (timestamp, broker, symbol) DO NOTHING
+                """,
+                records,
+            )

--- a/tasks/data_collection/reference_price_pipeline.py
+++ b/tasks/data_collection/reference_price_pipeline.py
@@ -1,0 +1,88 @@
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+import aiohttp
+import paho.mqtt.client as mqtt
+
+from core.services.timescale_client import TimescaleClient
+from core.task_base import BaseTask
+
+logging.basicConfig(level=logging.INFO)
+
+
+class ReferencePricePipeline(BaseTask):
+    """Fetch reference prices from broker endpoints, store them in TimescaleDB and
+    publish each price update to an MQTT topic."""
+
+    def __init__(self, name: str, frequency: timedelta, config: Dict[str, Any]):
+        super().__init__(name, frequency, config)
+        self.endpoints = config["endpoints"]
+        self.symbol = config.get("symbol", "BTCARS")
+        self.mqtt_broker = config.get("mqtt_broker", "localhost")
+        self.mqtt_port = config.get("mqtt_port", 1883)
+        self.mqtt_topic = config.get("mqtt_topic", "ar/reference_price")
+        self.ts_client = TimescaleClient(
+            host=config["timescale_config"].get("host", "localhost"),
+            port=config["timescale_config"].get("port", 5432),
+            user=config["timescale_config"].get("user", "admin"),
+            password=config["timescale_config"].get("password", "admin"),
+            database=config["timescale_config"].get("database", "timescaledb"),
+        )
+        self.mqtt_client = mqtt.Client()
+        self.mqtt_client.connect(self.mqtt_broker, self.mqtt_port)
+
+    async def execute(self):
+        await self.ts_client.connect()
+        async with aiohttp.ClientSession() as session:
+            records = []
+            for broker, url in self.endpoints.items():
+                try:
+                    async with session.get(url) as resp:
+                        data = await resp.json()
+                        price = float(data["price"])
+                        ts = datetime.utcnow().timestamp()
+                        records.append((ts, broker, self.symbol, price))
+                        message = json.dumps(
+                            {
+                                "broker": broker,
+                                "symbol": self.symbol,
+                                "price": price,
+                                "timestamp": ts,
+                            }
+                        )
+                        self.mqtt_client.publish(self.mqtt_topic, message)
+                        logging.info("Published price from %s: %s", broker, price)
+                except Exception as e:
+                    logging.error("Error fetching price from %s - %s", broker, e)
+            if records:
+                await self.ts_client.append_reference_prices("reference_prices", records)
+        await self.ts_client.close()
+
+
+async def main():
+    config = {
+        "endpoints": {
+            "ripio": "https://criptoya.com/api/ripio/btc/ars/1",
+            "satoshitango": "https://criptoya.com/api/satoshitango/btc/ars/1",
+        },
+        "symbol": "BTCARS",
+        "mqtt_broker": "localhost",
+        "mqtt_port": 1883,
+        "mqtt_topic": "ar/reference_price",
+        "timescale_config": {
+            "host": "localhost",
+            "port": 5432,
+            "user": "admin",
+            "password": "admin",
+            "database": "timescaledb",
+        },
+    }
+    task = ReferencePricePipeline("reference_price", timedelta(minutes=1), config)
+    await task.execute()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a sample pipeline that fetches reference prices from brokers
- store reference prices in TimescaleDB and publish to MQTT
- support new `create_reference_prices_table` and `append_reference_prices` helpers in `TimescaleClient`

## Testing
- `black --check core/services/timescale_client.py tasks/data_collection/reference_price_pipeline.py`
- `isort --check core/services/timescale_client.py tasks/data_collection/reference_price_pipeline.py`
- ❌ `pre-commit run --files core/services/timescale_client.py tasks/data_collection/reference_price_pipeline.py` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841da3e1784832b9ef20f3adbe3eedb